### PR TITLE
Add missing vulnerability report import

### DIFF
--- a/monitoring/server/index.js
+++ b/monitoring/server/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const morgan = require('morgan');
+const { generateUserFriendlyReport } = require('./vulnerability_templates');
 
 const PORT = process.env.PORT || 3000;
 const LOG_FILE = path.join(__dirname, 'reports.log');


### PR DESCRIPTION
## Summary
- import the vulnerability report generator into the monitoring server entry point so report generation can run

## Testing
- node index.js
- curl -s -X POST http://localhost:3000/api/vulnerability-scan -H 'Content-Type: application/json' -d '{"machine_id":"machine123","timestamp":"2024-05-30T13:00:00Z","vulnerabilities":["Outdated Software: Google Chrome\nVersion: 100.0\nSeverity: High"]}'
- curl -s http://localhost:3000/api/vulnerability-report/machine123


------
https://chatgpt.com/codex/tasks/task_e_68deabcd4294832492681f890aebd9cc