### PR TITLE
Potential fix for code scanning alert no. 30: Information exposure through an exception

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -100,18 +100,18 @@ def run_vbox_command(args):
 
     except FileNotFoundError:
         error_msg = f"Error: VBoxManage.exe not found at '{VBOXMANAGE_PATH}'. Please check the path."
-        print(error_msg)
-        return False, error_msg
+        logging.error(error_msg)
+        return False, "An internal error occurred while running the VM command."
 
     except subprocess.CalledProcessError as e:
         error_msg = f"Error executing command: {e}\n{e.stderr}"
-        print(error_msg)
-        return False, error_msg
+        logging.error(error_msg)
+        return False, "An internal error occurred while running the VM command."
 
     except subprocess.TimeoutExpired:
         error_msg = "Error: VBoxManage command timed out after 2 minutes."
-        print(error_msg)
-        return False, error_msg
+        logging.error(error_msg)
+        return False, "An internal error occurred while running the VM command."
 
 
 def revert_to_snapshot():
@@ -157,7 +157,7 @@ def start_simulation():
         yield "data: Reverting VM to clean snapshot...\n\n"
         success, output = revert_to_snapshot()
         if not success:
-            yield f"data: ERROR: {output}\n\n"
+            yield "data: ERROR: An internal server error occurred while executing the simulation.\n\n"
             yield "data: FINISHED\n\n"
             return
         yield "data: Revert successful.\n\n"


### PR DESCRIPTION
Potential fix for [https://github.com/EclipseWhetstone1/PenetrativeDocumentation/security/code-scanning/30](https://github.com/EclipseWhetstone1/PenetrativeDocumentation/security/code-scanning/30)

The best way to fix this issue is to ensure that error messages returned to users do not contain potentially sensitive information, such as exception object details or command output. Instead, return only a generic, unspecific error message in the API response. The detailed error should be logged server-side using Python's `logging` module. This means updating the places in `run_vbox_command` (inside all `except` blocks) so that when errors occur, the function logs the full error details, but only returns a generalized message to the caller. Then, update the downstream API endpoint logic (the event stream) to only display generic messages for errors. You'll need to make these changes entirely within `server/app.py` in the region shown, ensuring no functional change outside of error handling/output. Make sure the logging is set up for the errors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
